### PR TITLE
Bugfix to lexicalize_path

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,4 +1,6 @@
 # Changes
+- v3.2.1:
+   - Fix to `limit_to` param of `DependencyUtils.lexicalize_path`
 - v3.2.0:
     - `ProcessorsAPI` now inherits from `ProcessorsBaseAPI`
     - `ProcessorsBaseAPI` can be used with a [`docker` backend](https://hub.docker.com/r/myedibleenso/processors-server/)

--- a/processors/__init__.py
+++ b/processors/__init__.py
@@ -11,7 +11,7 @@ import json
 
 
 __title__ = 'py-processors'
-__version__ = '3.2.1'
+__version__ = '3.2.2'
 __ps_rec__ = '3.1.0' # known compatible version of server
 __author__ = 'Gus Hahn-Powell'
 __copyright__ = 'Copyright 2015 Gus Hahn-Powell'

--- a/processors/paths.py
+++ b/processors/paths.py
@@ -302,9 +302,9 @@ class DependencyUtils(object):
                     node_pattern = "[{}]".format(" & ".join(token_constraints))
                     # store lexicalized representation of node
                     lexicalized_path.append(node_pattern)
-                # append next edge
-                if i < len(relations):
-                    lexicalized_path.append(relations[i])
+            # append next edge
+            if i < len(relations):
+                lexicalized_path.append(relations[i])
         return lexicalized_path
 
     @staticmethod


### PR DESCRIPTION
This corrects an error where relations not corresponding to a node index in `limit_to` were not being included in the lexicalized path.